### PR TITLE
Bootstrap vcpkg toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
 
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "Vcpkg toolchain file")
+  endif()
+endif()
+
 project(occt-qopenglwidget-sample LANGUAGES CXX)
 
 add_subdirectory(occt-qopenglwidget)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "occt-qopenglwidget",
   "version": "0.1.0",
+  "builtin-baseline": "b1b19307e2d2ec1eefbdb7ea069de7d4bcd31f01",
   "dependencies": [
     "qtbase",
     "opencascade"


### PR DESCRIPTION
## Summary
- add CMake bootstrap to automatically use vcpkg toolchain when present
- record vcpkg baseline and dependencies in manifest

## Testing
- `git submodule update --init --depth 1 vcpkg` *(fails: fatal: unable to access 'https://github.com/microsoft/vcpkg.git/': CONNECT tunnel failed)*
- `cmake --preset default` *(fails: Could not find toolchain file: /workspace/occt-samples-qopenglwidget/vcpkg/scripts/buildsystems/vcpkg.cmake)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6")*


------
https://chatgpt.com/codex/tasks/task_e_68b4acb0d0908330849b9fe4acb1b77c