### PR TITLE
Include Qt6 OpenGLWidgets module

### DIFF
--- a/occt-qopenglwidget/CMakeLists.txt
+++ b/occt-qopenglwidget/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Widgets OpenGLWidgets REQUIRED)
 find_package(OpenCASCADE REQUIRED)
 
 add_executable(${PROJECT_NAME}
@@ -20,5 +20,5 @@ add_executable(${PROJECT_NAME}
     OcctQtTools.h
 )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets ${OpenCASCADE_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets Qt6::OpenGLWidgets ${OpenCASCADE_LIBRARIES})
 


### PR DESCRIPTION
## Summary
- ensure Qt's OpenGLWidgets module is discovered during configuration
- link sample with Qt6::OpenGLWidgets alongside existing dependencies

## Testing
- `cmake -S occt-qopenglwidget -B build` *(fails: Could not find a package configuration file provided by "Qt6" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b7137bec833087efb79777314398